### PR TITLE
feat(train): Added new FcdWriterProcessor that allows efficient writing of FCD Records

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,15 @@ which are used to configure the vehicles and the server respectively.
 *TseServerApp.json*
 ```json
 {
-    "storeRawFcd": false,
+      "fcdDataStorage": {
+        "type": "FcdDatabaseHelper",
+        "inMemory": false
+    },
     "databasePath": null,
     "databaseFileName": null,
-    "garbageCollectionInterval" : "60min",
-    "garbageLifeTime" : "30min",
+    "isPersistent": false,
+    "unitRemovalInterval" : "60min",
+    "unitExpirationTime" : "30min",
     "traversalBasedProcessors": [
         {
             "type": "SpatioTemporalProcessor",
@@ -154,6 +158,24 @@ which are used to configure the vehicles and the server respectively.
 }
 ```
 
+**Write all FCD into the database**
+For different purposes it can be useful to write all received FCD Records into the database.
+To achieve this, you can add the `FcdWriterProcessor` to your list of `timeBasedProcessors`.
+
+```json
+{
+    "timeBasedProcessors": [
+        {
+            "type": "FcdWriterProcessor",
+            "triggerInterval": "30min"
+        }
+    ]
+}
+```
+
+## Evaluation Utilities
+Within the **evaluation** directory, we bundled python scripts for reading and preprocessing simulation data.
+The **usage_example** Jupyter Notebook should explain the usage of the methods.
 
 [^1]: Yoon, Jungkeun; Noble, Brian; Liu, Mingyan. *Surface street traffic estimation*. In: Proceedings of the 5th international conference on Mobile systems, applications and services. 2007. S. 220-232
 [^2]: Schrab, K., Protzmann, R., Radusch, I. (2023). *A Large-Scale Traffic Scenario of Berlin for Evaluating Smart Mobility Applications*. In: Nathanail, E.G., Gavanas, N., Adamos, G. (eds) Smart Energy for Smart Transport. CSUM 2022. Lecture Notes in Intelligent Transportation and Infrastructure. Springer, Cham. https://doi.org/10.1007/978-3-031-23721-8_24

--- a/configs/best-scenario/application/TseServerApp.json
+++ b/configs/best-scenario/application/TseServerApp.json
@@ -1,9 +1,13 @@
 {
-    "storeRawFcd": false,
+    "fcdDataStorage": {
+        "type": "FcdDatabaseHelper",
+        "inMemory": false
+    },
     "databasePath": null,
     "databaseFileName": null,
-    "garbageCollectionInterval" : "60min",
-    "garbageLifeTime" : "30min",
+    "isPersistent": false,
+    "unitRemovalInterval" : "60min",
+    "unitExpirationTime" : "30min",
     "traversalBasedProcessors": [
         {
             "type": "SpatioTemporalProcessor",
@@ -17,6 +21,10 @@
             "defaultRedLightDuration": "45s",
             "minTraversalsForThreshold": 10,
             "recomputeAllRtsmWithNewThreshold": false
+        },
+        {
+            "type": "FcdWriterProcessor",
+            "triggerInterval": -1
         }
     ]
 }

--- a/src/main/java/com/dcaiti/mosaic/app/tse/TseKernel.java
+++ b/src/main/java/com/dcaiti/mosaic/app/tse/TseKernel.java
@@ -57,9 +57,6 @@ public class TseKernel extends FxdKernel<FcdRecord, FcdTraversal, FcdUpdateMessa
 
     @Override
     protected void additionalProcessingOfUpdate(FcdUpdateMessage update) {
-        if (config.storeRawFcd) {
-            fcdDataStorage.insertFcdRecords(update.getRouting().getSource().getSourceName(), update.getRecords().values());
-        }
     }
 
     @Override

--- a/src/main/java/com/dcaiti/mosaic/app/tse/config/CTseServerApp.java
+++ b/src/main/java/com/dcaiti/mosaic/app/tse/config/CTseServerApp.java
@@ -63,11 +63,6 @@ public class CTseServerApp extends CFxdReceiverApp<FcdRecord, FcdTraversal, FcdU
      * Optional path to the db file. If there is none, one will be created.
      */
     public String databaseFileName = null;
-    /**
-     * If {@code true}, all {@link FcdRecord FcdRecords} will be stored to the database.
-     * Can be turned off, to safe storage and compute time, as metrics are computed from memory, not from records in the database.
-     */
-    public boolean storeRawFcd = false;
 
     @Override
     public String toString() {

--- a/src/main/java/com/dcaiti/mosaic/app/tse/data/DatabaseAccess.java
+++ b/src/main/java/com/dcaiti/mosaic/app/tse/data/DatabaseAccess.java
@@ -29,7 +29,7 @@ public interface DatabaseAccess {
      * Method giving processors access to the {@link Database Network Database} and the {@link FcdDataStorage}.
      *
      * @param networkDatabase   reference to the {@link Database Network Database}
-     * @param fcdDatabaseHelper reference to the {@link FcdDataStorage}
+     * @param fcdDataStorage reference to the {@link FcdDataStorage}
      */
-    void withDataStorage(Database networkDatabase, FcdDataStorage fcdDatabaseHelper);
+    void withDataStorage(Database networkDatabase, FcdDataStorage fcdDataStorage);
 }

--- a/src/main/java/com/dcaiti/mosaic/app/tse/persistence/FcdDataStorage.java
+++ b/src/main/java/com/dcaiti/mosaic/app/tse/persistence/FcdDataStorage.java
@@ -49,7 +49,7 @@ public interface FcdDataStorage {
 
     String getStatisticsString();
 
-    void insertFcdRecords(String vehicleId, Collection<FcdRecord> records);
+    void insertFcdRecords(Map<String, Collection<FcdRecord>> records);
 
     void insertTraversalMetrics(String vehicleId, long timestamp, String connectionId, String nextConnection,
                                 double spatialMeanSpeed, double temporalMeanSpeed, double naiveMeanSpeed,

--- a/src/main/java/com/dcaiti/mosaic/app/tse/persistence/FcdDatabaseHelper.java
+++ b/src/main/java/com/dcaiti/mosaic/app/tse/persistence/FcdDatabaseHelper.java
@@ -266,9 +266,9 @@ public class FcdDatabaseHelper implements FcdDataStorage {
         try (PreparedStatement statement = connection.prepareStatement(sqlRecordInsert)) {
             connection.setAutoCommit(false);
             int i = 0;
-            for (String vehicleId : records.keySet()) {
-                for (FcdRecord record : records.get(vehicleId)) {
-                    statement.setString(1, vehicleId);
+            for (Map.Entry<String, Collection<FcdRecord>> recordEntry : records.entrySet()) {
+                for (FcdRecord record : recordEntry.getValue()) {
+                    statement.setString(1, recordEntry.getKey());
                     statement.setLong(2, record.getTimeStamp());
                     statement.setDouble(3, record.getPosition().getLatitude());
                     statement.setDouble(4, record.getPosition().getLongitude());
@@ -277,12 +277,13 @@ public class FcdDatabaseHelper implements FcdDataStorage {
                     statement.setDouble(7, record.getSpeed());
                     statement.addBatch();
                     i++;
-                    if (i % 1000 == 0 || i == records.size()) {
+                    if (i % 1000 == 0) { // make sure the batch statement is executed every 1000 entries
                         statement.executeBatch();
                         connection.commit();
                     }
                 }
             }
+            // finalize statement by executing non-committed statements
             statement.executeBatch();
             connection.commit();
             connection.setAutoCommit(true);

--- a/src/main/java/com/dcaiti/mosaic/app/tse/processors/FcdWriterProcessor.java
+++ b/src/main/java/com/dcaiti/mosaic/app/tse/processors/FcdWriterProcessor.java
@@ -1,0 +1,63 @@
+package com.dcaiti.mosaic.app.tse.processors;
+
+import com.dcaiti.mosaic.app.fxd.data.FcdRecord;
+import com.dcaiti.mosaic.app.fxd.messages.FcdUpdateMessage;
+import com.dcaiti.mosaic.app.tse.data.DatabaseAccess;
+import com.dcaiti.mosaic.app.tse.persistence.FcdDataStorage;
+import org.eclipse.mosaic.lib.database.Database;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This processor can be used to store all received FCD Records within the {@link FcdDataStorage}.
+ * This will be executed every {@link #triggerInterval}.
+ */
+public class FcdWriterProcessor extends TimeBasedProcessor<FcdRecord, FcdUpdateMessage> implements DatabaseAccess {
+
+    private static final String IDENTIFIER = createIdentifier(FcdWriterProcessor.class);
+
+    private FcdDataStorage fcdDataStorage;
+    private final Map<String, Collection<FcdRecord>> recordBuffer = new HashMap<>();
+
+    @Override
+    public String getIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public void withDataStorage(Database networkDatabase, FcdDataStorage fcdDataStorage) {
+        this.fcdDataStorage = fcdDataStorage;
+    }
+
+    @Override
+    public void shutdown(long shutdownTime) {
+        logger.info("Final Persistence of FCD Records for {} vehicles.", recordBuffer.keySet().size());
+        persistRecords();
+    }
+
+    @Override
+    public void handleUpdate(FcdUpdateMessage update) {
+        String vehicleId = update.getRouting().getSource().getSourceName();
+        // here we don't profit from the sorted map, so we just store them as a collection right away
+        Collection<FcdRecord> recordList = new ArrayList<>(update.getRecords().values());
+        if (!recordBuffer.containsKey(vehicleId)) {
+            recordBuffer.put(vehicleId, recordList);
+        } else {
+            recordBuffer.get(vehicleId).addAll(recordList);
+        }
+    }
+
+    @Override
+    public void triggerEvent(long eventTime) {
+        logger.info("Persisting FCD Records for {} vehicles.", recordBuffer.keySet().size());
+        persistRecords();
+    }
+
+    private void persistRecords() {
+        fcdDataStorage.insertFcdRecords(recordBuffer);
+        recordBuffer.clear();
+    }
+}


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

* with this PR we introduce a new `TimeBasedProcessor` which can be configured to write the raw `FcdRecords` into the sqlite database
* this replaces the previous configuration parameter `storeRawFcd`
* execution time was drastically improved as records are now buffered before writing to the database, reducing write operations which was the biggest time sucker

## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

* Readme was adjusted accordingly
 
## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.

## Special notes to reviewer

