### PR TITLE
fix(v2x): Adjustments to API change in V2xMessage getPayLoad -> getPayload

### DIFF
--- a/src/main/java/com/dcaiti/mosaic/app/fxd/messages/FxdUpdateMessage.java
+++ b/src/main/java/com/dcaiti/mosaic/app/fxd/messages/FxdUpdateMessage.java
@@ -23,6 +23,7 @@ import org.eclipse.mosaic.lib.objects.v2x.V2xMessage;
 import com.google.common.collect.Maps;
 
 import java.util.SortedMap;
+import java.util.TreeMap;
 import javax.annotation.Nonnull;
 
 /**
@@ -50,7 +51,7 @@ public abstract class FxdUpdateMessage<RecordT extends FxdRecord> extends V2xMes
 
     public final SortedMap<Long, RecordT> getRecords() {
         // always return copy of records, in case list is processed by multiple processors
-        return Maps.newTreeMap(records);
+        return records == null ? new TreeMap<>() : Maps.newTreeMap(records);
     }
 
     public boolean isFinal() {
@@ -59,13 +60,13 @@ public abstract class FxdUpdateMessage<RecordT extends FxdRecord> extends V2xMes
 
     @Nonnull
     @Override
-    public EncodedPayload getPayLoad() {
+    public EncodedPayload getPayload() {
         return new EncodedPayload(calculateMessageLength());
     }
 
     /**
-     * Method that estimates the length of an average {@link FxdUpdateMessage UpdateMessage} adding the baseline length of required fields with
-     * the length of the specialized {@link FxdUpdateMessage FxdUpdateMessages}.
+     * Method that estimates the length of an average {@link FxdUpdateMessage UpdateMessage} adding the baseline length of
+     * required fields with the length of the specialized {@link FxdUpdateMessage UpdateMessages}.
      */
     public long calculateMessageLength() {
         return 10 // "header size"


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

* This PR makes adjustments according to API changes in `V2xMessage#getPayload()`
* added additional null safety
* some formatting
* This requires https://github.com/eclipse/mosaic/pull/375 to be merged

## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->
No

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.

## Special notes to reviewer

