### PR TITLE
fix: Refactored apps to use new MessageRoutingBuilder methods

### DIFF
--- a/src/main/java/com/dcaiti/mosaic/app/fxd/FxdTransmitterApp.java
+++ b/src/main/java/com/dcaiti/mosaic/app/fxd/FxdTransmitterApp.java
@@ -117,7 +117,7 @@ public abstract class FxdTransmitterApp<
     }
 
     protected MessageRouting getMessageRouting() {
-        return getOs().getCellModule().createMessageRouting().topoCast(config.receiverId);
+        return getOs().getCellModule().createMessageRouting().destination(config.receiverId).topological().build();
     }
 
     protected void transmitUpdate(UpdateT fxdUpdate) {

--- a/src/main/java/com/dcaiti/mosaic/app/tse/FxdReceiverApp.java
+++ b/src/main/java/com/dcaiti/mosaic/app/tse/FxdReceiverApp.java
@@ -89,7 +89,10 @@ public abstract class FxdReceiverApp<
             kernel.processUpdate(update);
         } else { // forward message to kernel to potentially be handled by message-based processors
             MessageRouting responseRouting =
-                    getOs().getCellModule().createMessageRouting().topoCast(message.getRouting().getSource().getSourceName());
+                    getOs().getCellModule().createMessageRouting()
+                            .destination(message.getRouting().getSource().getSourceName())
+                            .topological()
+                            .build();
             kernel.handleMessageAdvanced(receivedV2xMessage, responseRouting) // get all responses
                     .forEach(response -> getOs().getCellModule().sendV2xMessage(response)); // send all responses
         }


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

- Changed usages of CellMessageRoutingBuilder 
- Based on internal issue 917

## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

- Addressed in internal issue 911

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.

## Special notes to reviewer

